### PR TITLE
cmake: sanitize variable for CheckCxxCompilerFlag

### DIFF
--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -82,6 +82,7 @@ else ()
   # Flags commonly used on Linux and Mac.  Adjust to taste.
   FOREACH(FLAG
         -fdiagnostics-show-option
+        -Qunused-arguments
         -Wall
         -Wempty-body
         -Werror
@@ -97,8 +98,9 @@ else ()
         -Wvla
         -Wwrite-strings
     )
-    CHECK_CXX_COMPILER_FLAG(${FLAG} COMPILER_SUPPORTS_${FLAG})
-    IF(COMPILER_SUPPORTS_${FLAG})
+    string(REGEX REPLACE "[^a-zA-Z0-9_]" _ SANITIZED_FLAG ${FLAG})
+    CHECK_CXX_COMPILER_FLAG(${FLAG} COMPILER_SUPPORTS_${SANITIZED_FLAG})
+    IF(COMPILER_SUPPORTS_${SANITIZED_FLAG})
       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
     ENDIF()
   ENDFOREACH()


### PR DESCRIPTION
This commit copied from @tomjakubowski

Since CMake passes this variable name to the compiler as a
definition (via -D), it has to be a legal macro name or funkiness can
ensue.

Also, now that `-Werror` works, it turns out that
`-Wno-unused-command-argument` has no effect on clang's linker, and so
we must include `-Qunused-arguments` (which the linker does pay
attention to) in the list of flags, or the linker will turn a warning
about unused arguments (like `-pthread`) into an error (because of
`-Werror`).