### PR TITLE
Remove '-G "Unix Makefiles"' from cmake args

### DIFF
--- a/templates/project.yaml
+++ b/templates/project.yaml
@@ -8,8 +8,7 @@ name: '{{project_name}}'
 # Build task
 # ----------
 # Comma-separated list of command line arguments passed to cmake
-cmake-args: ['-G "Unix Makefiles"',
-             '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+cmake-args: ['-DCMAKE_BUILD_TYPE=RelWithDebInfo',
              '-DCMAKE_EXPORT_COMPILE_COMMANDS=1']
 
 # Comma-separated list of arguments passed to cmake --build


### PR DESCRIPTION
This is redundant in some cases and wrong in others: on Windows it would
certainly produce the wrong thing, and on OS X and Linux cmake defaults
to "Unix Makefiles" anyway.  It also interferes with my cmake wrapper
script that tries to force cmake to use Ninja.